### PR TITLE
fix(vm): make findAll linear by stopping matchAt when no threads remain

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -330,6 +330,9 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    // The findAll-quadratic regression test uses libc's monotonic clock for a
+    // time bound (Zig 0.16 std.time has no Timer/nanoTimestamp).
+    regression_tests.root_module.link_libc = true;
     const run_regression_tests = b.addRunArtifact(regression_tests);
     test_step.dependOn(&run_regression_tests.step);
 

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -227,6 +227,17 @@ pub const VM = struct {
             next_threads.clearRetainingCapacity();
 
             pos += 1;
+
+            // No live threads remain. matchAt only ever seeds the start-state
+            // thread (at start_pos), and threads can only be spawned by cloning
+            // existing ones, so once the set is empty no further match can
+            // begin from this start_pos — the longest match found so far
+            // (last_match) is final. Without this break the loop walks every
+            // remaining byte doing nothing; because findAll restarts matchAt
+            // per match, that dead-walk is what makes findAll O(n^2). Any
+            // accepting state reached on the consumed input was already
+            // recorded by the accept check at the top of the loop.
+            if (current_threads.items.len == 0) break;
         }
 
         // Return the last (longest) match we found

--- a/tests/regression.zig
+++ b/tests/regression.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Regex = @import("regex").Regex;
 const RegexError = @import("regex").RegexError;
 
@@ -178,4 +179,91 @@ test "regression: double pattern compile and deinit" {
         defer regex.deinit();
         try std.testing.expect(try regex.isMatch("def"));
     }
+}
+
+// --- findAll quadratic blowup (issue: "findAll is O(n^2), not linear") ---
+//
+// Before the fix, matchAt kept iterating to input.len after all threads died,
+// and findAll restarted matchAt per match, so a scan with m matches over n
+// bytes cost ~O(n*m). The guard below doubles the input and checks the time
+// ratio: a linear scan stays near ~2x, the pre-fix quadratic path was ~4x and
+// growing. A ratio (not an absolute bound) keeps this independent of build
+// mode (Debug vs ReleaseFast) and machine speed.
+
+fn monotonicNs() u64 {
+    const clk: std.c.clockid_t = switch (builtin.os.tag) {
+        .macos, .ios, .tvos, .watchos, .visionos => .UPTIME_RAW,
+        else => .MONOTONIC,
+    };
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(clk, &ts);
+    return @as(u64, @intCast(ts.sec)) * 1_000_000_000 + @as(u64, @intCast(ts.nsec));
+}
+
+const FindAllScan = struct { ns: u64, count: usize, first_start: usize, last_end: usize };
+
+fn timeFindAll(allocator: std.mem.Allocator, regex: *const Regex, n: usize) !FindAllScan {
+    const buf = try allocator.alloc(u8, n);
+    defer allocator.free(buf);
+    @memset(buf, '.');
+    var i: usize = 0;
+    while (i + 8 <= n) : (i += 64) @memcpy(buf[i .. i + 8], "Sherlock");
+
+    // Warm up (allocator caches, code paths), then take the min of a few runs
+    // to suppress scheduler noise without depending on absolute timing.
+    {
+        const warm = try regex.findAll(allocator, buf);
+        for (warm) |*m| {
+            var mm = m.*;
+            mm.deinit(allocator);
+        }
+        allocator.free(warm);
+    }
+
+    var best: u64 = std.math.maxInt(u64);
+    var count: usize = 0;
+    var first_start: usize = 0;
+    var last_end: usize = 0;
+    var rep: usize = 0;
+    while (rep < 3) : (rep += 1) {
+        const t0 = monotonicNs();
+        const matches = try regex.findAll(allocator, buf);
+        const dt = monotonicNs() - t0;
+        count = matches.len;
+        if (matches.len > 0) {
+            first_start = matches[0].start;
+            last_end = matches[matches.len - 1].end;
+        }
+        for (matches) |*m| {
+            var mm = m.*;
+            mm.deinit(allocator);
+        }
+        allocator.free(matches);
+        if (dt < best) best = dt;
+    }
+    return .{ .ns = best, .count = count, .first_start = first_start, .last_end = last_end };
+}
+
+test "regression: findAll scales linearly (no O(n^2) blowup)" {
+    const allocator = std.testing.allocator;
+
+    var regex = try Regex.compile(allocator, "Sherlock");
+    defer regex.deinit();
+
+    const n1: usize = 16 * 1024;
+    const n2: usize = 32 * 1024; // exactly 2x
+
+    const r1 = try timeFindAll(allocator, &regex, n1);
+    const r2 = try timeFindAll(allocator, &regex, n2);
+
+    // Correctness: a "Sherlock" every 64 bytes, found at the right places.
+    try std.testing.expectEqual(n1 / 64, r1.count);
+    try std.testing.expectEqual(n2 / 64, r2.count);
+    try std.testing.expectEqual(@as(usize, 0), r2.first_start);
+    try std.testing.expectEqual(((n2 - 8) / 64) * 64 + 8, r2.last_end);
+
+    // Linearity guard: doubling input must not more-than-triple the time.
+    // Linear ≈ 2x; the pre-fix quadratic path was ≈ 4x (and worsening).
+    try std.testing.expect(r1.ns > 0);
+    try std.testing.expect(r2.ns * 10 < r1.ns * 30); // r2/r1 < 3.0
 }


### PR DESCRIPTION
Fixes: https://github.com/zig-utils/zig-regex/issues/6

matchAt seeds only the start-state thread, yet after a match completed and all threads died it kept iterating to input.len doing nothing. findAll restarts matchAt per match, so that dead-walk was paid Σ(n − posᵢ) ≈ O(n²): a 64 KiB scan with a match every 64 bytes took ~6.5 s. This also made findIter/replaceAll/split unusable past a few KB and contradicted the documented O(n×m) guarantee.

Break out of the matchAt loop as soon as the live thread set is empty; no further match can begin from this start_pos, and any accept on the consumed input was already recorded. Restores O(n·states) end to end.

Reproduction (issue), ReleaseFast: 16→7.7ms 32→15.4 64→30.8 128→56.3 256→119ms — ~2× per doubling (was ~4×). Match counts unchanged.

Adds a build-mode-independent regression test (time ratio of input vs 2×input must stay sub-3×); links libc for tests/regression.zig to get a monotonic clock (Zig 0.16 std.time has none).